### PR TITLE
feat(editor): add default editor class

### DIFF
--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -986,7 +986,7 @@ L.Marker.include(EditableMixin);
 L.Polyline.include({
 
     getEditorClass: function (map) {
-        return map.options.polylineEditorClass;
+        return map.options.polylineEditorClass || L.Editable.PolylineEditor;
     }
 
 });
@@ -994,7 +994,7 @@ L.Polyline.include({
 L.Polygon.include({
 
     getEditorClass: function (map) {
-        return map.options.polygonEditorClass;
+        return map.options.polygonEditorClass || L.Editable.PolygonEditor;
     },
 
     polygonFromLatLng: function (latlng, latlngs) {
@@ -1016,7 +1016,7 @@ L.Polygon.include({
 L.Marker.include({
 
     getEditorClass: function (map) {
-        return map.options.markerEditorClass;
+        return map.options.markerEditorClass || L.Editable.MarkerEditor;
     }
 
 });


### PR DESCRIPTION
This PR try to solve an issue where I can't pass any options to map. So if no default editor class is defined there will be an RTE. 
As probably most user would probably have no need to override the default editor, I've added default editor classes as fallbacks if none specified as options at map initialization phase.

What we gain is that it is not necessary to provide default options.
