### PR TITLE
fix polygon vertexCanBeDeleted

### DIFF
--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -1139,7 +1139,7 @@
         },
 
         vertexCanBeDeleted: function (vertex) {
-            if (vertex.latlngs === this.getLatLngs()) return L.Editable.PathEditor.prototype.vertexCanBeDeleted.call(this, vertex);
+            if (vertex.latlngs === this.getLatLngs()[0]) return L.Editable.PathEditor.prototype.vertexCanBeDeleted.call(this, vertex);
             else return true;  // Holes can be totally deleted without removing the layer itself
         },
 


### PR DESCRIPTION
Fixes bug with vertexCanBeDeleted. Without it all vertices can be deleted on a polygon.

[0] might be too simple of a fix, I don't know how multipolygons work in editable.