### PR TITLE
fix polyline line guide not attached after continue forward

### DIFF
--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -1059,17 +1059,19 @@
 
     L.Editable.PolylineEditor = L.Editable.PathEditor.extend({
 
-        startDrawingBackward: function (latlngs) {
+        startDrawingBackward: function () {
             this._drawing = L.Editable.BACKWARD;
-            this.startDrawing(latlngs);
-            this.tools.attachBackwardLineGuide();
+            this.startDrawing();
         },
 
         continueBackward: function (latlngs) {
             if (this.drawing()) return;
             latlngs = latlngs || this.getDefaultLatLngs();
             this.setDrawnLatLngs(latlngs);
-            this.tools.anchorBackwardLineGuide(latlngs[0]);
+            if (latlngs.length > 0) {
+                this.tools.attachBackwardLineGuide();
+                this.tools.anchorBackwardLineGuide(latlngs[0]);
+            }
             this.startDrawingBackward();
         },
 
@@ -1077,7 +1079,10 @@
             if (this.drawing()) return;
             latlngs = latlngs || this.getDefaultLatLngs();
             this.setDrawnLatLngs(latlngs);
-            this.tools.anchorForwardLineGuide(latlngs[latlngs.length - 1]);
+            if (latlngs.length > 0) {
+                this.tools.attachForwardLineGuide();
+                this.tools.anchorForwardLineGuide(latlngs[latlngs.length - 1]);
+            }
             this.startDrawingForward();
         },
 

--- a/test/PolylineEditor.js
+++ b/test/PolylineEditor.js
@@ -236,7 +236,7 @@ describe('L.PolylineEditor', function() {
         it('should return true if an editor is active and drawing forward', function () {
             var layer = L.polyline([p2ll(100, 150), p2ll(150, 200)]).addTo(this.map);
             layer.enableEdit();
-            layer.editor.continueBackward();
+            layer.editor.continueForward();
             assert.ok(layer.editor.drawing());
             layer.remove();
         });
@@ -246,6 +246,46 @@ describe('L.PolylineEditor', function() {
             layer.enableEdit();
             layer.editor.continueBackward();
             assert.ok(layer.editor.drawing());
+            layer.remove();
+        });
+
+    });
+
+    describe('#continue forward', function () {
+
+        it('should attach forward line guide if points were drawn', function () {
+            var layer = L.polyline([p2ll(100, 150), p2ll(150, 200)]).addTo(this.map);
+            layer.enableEdit();
+            layer.editor.continueForward();
+            assert.equal(this.map.editTools.editLayer.hasLayer(this.map.editTools.forwardLineGuide), true, 'forward line guide is attached');
+            layer.remove();
+        });
+
+        it('should not attach forward line guide if no points were drawn', function () {
+            var layer = L.polyline([]).addTo(this.map);
+            layer.enableEdit();
+            layer.editor.continueForward();
+            assert.equal(this.map.editTools.editLayer.hasLayer(this.map.editTools.forwardLineGuide), false, 'forward line guide is not attached');
+            layer.remove();
+        });
+
+    });
+
+    describe('#continue backward', function () {
+
+        it('should attach backward line guide if points were drawn', function () {
+            var layer = L.polyline([p2ll(100, 150), p2ll(150, 200)]).addTo(this.map);
+            layer.enableEdit();
+            layer.editor.continueBackward();
+            assert.equal(this.map.editTools.editLayer.hasLayer(this.map.editTools.backwardLineGuide), true, 'backward line guide is attached');
+            layer.remove();
+        });
+
+        it('should not attach backward line guide if no points were drawn', function () {
+            var layer = L.polyline([]).addTo(this.map);
+            layer.enableEdit();
+            layer.editor.continueBackward();
+            assert.equal(this.map.editTools.editLayer.hasLayer(this.map.editTools.backwardLineGuide), false, 'backward line guide is not attached');
             layer.remove();
         });
 


### PR DESCRIPTION
Calling `continueForward()` does not show the dashed line guide for polylines. `continueBackward()` works fine therefore I created a similar `startDrawingForward` function to attach the line guide.