### PR TITLE
Some documentation and Leafdoc generated API reference fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - BREAKING editorClass are now properly looked in editTools.options instead of map (cf #92)
 - removed Leaflet as peerDependency (cf #72)
-- fixed error in canvas due to guides being added to early (cf #80)
-- added path dragging (when [Path.Drag.js](https://github.com/Leaflet/Path.Drag.js) is loaded
+- fixed error in canvas due to guides being added too early (cf #80)
+- added path dragging (when [Path.Drag.js](https://github.com/Leaflet/Path.Drag.js) is loaded)
 - allow to draw a rectangle in any direction (cf #87)
 - fixed editable:drawing:commit being fired on mousedown instead of mouseup for circle and rectangle (cf #70)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Make geometries editable in Leaflet.
 Leaflet release, please use the `leaflet0.7` branch.**
 
 
-This is not a plug and play UI, and will not. This is a minimal, lightweight,
+This is not a plug and play UI, and will not be. This is a minimal, lightweight,
 and fully extendable API to control editing of geometries. So you can easily
 build your own UI with your own needs and choices.
 
@@ -19,7 +19,7 @@ Design keys:
 
 - only the core needs
 - no UI, instead hooks everywhere needed
-- everything programatically controlable
+- everything programmatically controllable
 - MultiPolygon/MultiPolyline support
 - Polygons' holes support
 - touch support

--- a/doc/api.html
+++ b/doc/api.html
@@ -48,7 +48,7 @@ See <a href="#editable"><code>Editable</code></a> events for the list of events 
 		<td><code><b>editToolsClass</b></code></td>
 		<td><code>class</code>
 		<td><code>L.Editable</code></td>
-		<td>Class to be used as vertex, for path editing</td>
+		<td>Class to be used as vertex, for path editing.</td>
 	</tr>
 	<tr id='map-editable'>
 		<td><code><b>editable</b></code></td>
@@ -135,55 +135,55 @@ the behaviour: using options, listening to events, or extending.</p>
 		<td><code><b>polygonClass</b></code></td>
 		<td><code>class</code>
 		<td><code>L.Polygon</code></td>
-		<td>Class to be used when creating a new Polygon</td>
+		<td>Class to be used when creating a new Polygon.</td>
 	</tr>
 	<tr id='editable-polylineclass'>
 		<td><code><b>polylineClass</b></code></td>
 		<td><code>class</code>
 		<td><code>L.Polyline</code></td>
-		<td>Class to be used when creating a new Polyline</td>
+		<td>Class to be used when creating a new Polyline.</td>
 	</tr>
 	<tr id='editable-markerclass'>
 		<td><code><b>markerClass</b></code></td>
 		<td><code>class</code>
 		<td><code>L.Marker</code></td>
-		<td>Class to be used when creating a new Marker</td>
+		<td>Class to be used when creating a new Marker.</td>
 	</tr>
 	<tr id='editable-rectangleclass'>
 		<td><code><b>rectangleClass</b></code></td>
 		<td><code>class</code>
 		<td><code>L.Rectangle</code></td>
-		<td>Class to be used when creating a new Rectangle</td>
+		<td>Class to be used when creating a new Rectangle.</td>
 	</tr>
 	<tr id='editable-circleclass'>
 		<td><code><b>circleClass</b></code></td>
 		<td><code>class</code>
 		<td><code>L.Circle</code></td>
-		<td>Class to be used when creating a new Circle</td>
+		<td>Class to be used when creating a new Circle.</td>
 	</tr>
 	<tr id='editable-drawingcssclass'>
 		<td><code><b>drawingCSSClass</b></code></td>
 		<td><code>string</code>
 		<td><code>&#x27;leaflet-editable-drawing&#x27;</code></td>
-		<td>CSS class to be added to the map container while drawing</td>
+		<td>CSS class to be added to the map container while drawing.</td>
 	</tr>
 	<tr id='editable-drawingcursor'>
 		<td><code><b>drawingCursor</b></code></td>
 		<td><code>const</code>
 		<td><code>&#x27;crosshair&#x27;</code></td>
-		<td>cursor mode set to the map while drawing</td>
+		<td>Cursor mode set to the map while drawing.</td>
 	</tr>
 	<tr id='editable-editlayer'>
 		<td><code><b>editLayer</b></code></td>
 		<td><code>Layer</code>
 		<td><code>new L.LayerGroup()</code></td>
-		<td>Layer used to store edit tools (vertex, line guide…)</td>
+		<td>Layer used to store edit tools (vertex, line guide…).</td>
 	</tr>
 	<tr id='editable-featureslayer'>
 		<td><code><b>featuresLayer</b></code></td>
 		<td><code>Layer</code>
 		<td><code>new L.LayerGroup()</code></td>
-		<td>Default layer used to store drawn features (marker, polyline…)</td>
+		<td>Default layer used to store drawn features (Marker, Polyline…).</td>
 	</tr>
 	<tr id='editable-polylineeditorclass'>
 		<td><code><b>polylineEditorClass</b></code></td>
@@ -231,7 +231,7 @@ the behaviour: using options, listening to events, or extending.</p>
 		<td><code><b>vertexMarkerClass</b></code></td>
 		<td><code>class</code>
 		<td><code>VertexMarker</code></td>
-		<td>Class to be used as vertex, for path editing</td>
+		<td>Class to be used as vertex, for path editing.</td>
 	</tr>
 	<tr id='editable-middlemarkerclass'>
 		<td><code><b>middleMarkerClass</b></code></td>
@@ -259,30 +259,35 @@ the behaviour: using options, listening to events, or extending.</p>
 		<td><code><a href='#layerevent'>LayerEvent</a></code></td>
 		<td>Fired when a new feature (Marker, Polyline…) is created.</td>
 	</tr>
-	<tr id='editable-editable-enable'>
-		<td><code><b>editable.enable</b>
+	<tr id='editable-editable:enable'>
+		<td><code><b>editable:enable</b>
 		<td><code>Event</code></td>
 		<td>Fired when an existing feature is ready to be edited.</td>
 	</tr>
-	<tr id='editable-editable-disable'>
-		<td><code><b>editable.disable</b>
+	<tr id='editable-editable:disable'>
+		<td><code><b>editable:disable</b>
 		<td><code>Event</code></td>
 		<td>Fired when an existing feature is not ready anymore to be edited.</td>
 	</tr>
-	<tr id='editable-editable-editing'>
-		<td><code><b>editable.editing</b>
+	<tr id='editable-editable:editing'>
+		<td><code><b>editable:editing</b>
 		<td><code>Event</code></td>
 		<td>Fired as soon as any change is made to the feature geometry.</td>
 	</tr>
-	<tr id='editable-editable-dragstart'>
-		<td><code><b>editable.dragstart</b>
+	<tr id='editable-editable:dragstart'>
+		<td><code><b>editable:dragstart</b>
 		<td><code>Event</code></td>
 		<td>Fired before a path feature is dragged.</td>
 	</tr>
-	<tr id='editable-editable-drag'>
-		<td><code><b>editable.drag</b>
+	<tr id='editable-editable:drag'>
+		<td><code><b>editable:drag</b>
 		<td><code>Event</code></td>
 		<td>Fired when a path feature is being dragged.</td>
+	</tr>
+	<tr id='editable-editable:dragend'>
+		<td><code><b>editable:dragend</b>
+		<td><code>Event</code></td>
+		<td>Fired after a path feature has been dragged.</td>
 	</tr>
 </tbody></table>
 </section><section data-type='[object Object]'>
@@ -295,55 +300,50 @@ the behaviour: using options, listening to events, or extending.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='editable-editable-drawing-start'>
-		<td><code><b>editable.drawing.start</b>
+	<tr id='editable-editable:drawing:start'>
+		<td><code><b>editable:drawing:start</b>
 		<td><code>Event</code></td>
 		<td>Fired when a feature is to be drawn.</td>
 	</tr>
-	<tr id='editable-editable-drawing-end'>
-		<td><code><b>editable.drawing.end</b>
+	<tr id='editable-editable:drawing:end'>
+		<td><code><b>editable:drawing:end</b>
 		<td><code>Event</code></td>
 		<td>Fired when a feature is not drawn anymore.</td>
 	</tr>
-	<tr id='editable-editable-drawing-cancel'>
-		<td><code><b>editable.drawing.cancel</b>
+	<tr id='editable-editable:drawing:cancel'>
+		<td><code><b>editable:drawing:cancel</b>
 		<td><code>Event</code></td>
 		<td>Fired when user cancel drawing while a feature is being drawn.</td>
 	</tr>
-	<tr id='editable-editable-drawing-commit'>
-		<td><code><b>editable.drawing.commit</b>
+	<tr id='editable-editable:drawing:commit'>
+		<td><code><b>editable:drawing:commit</b>
 		<td><code>Event</code></td>
 		<td>Fired when user finish drawing a feature.</td>
 	</tr>
-	<tr id='editable-editable-drawing-mousedown'>
-		<td><code><b>editable.drawing.mousedown</b>
+	<tr id='editable-editable:drawing:mousedown'>
+		<td><code><b>editable:drawing:mousedown</b>
 		<td><code>Event</code></td>
-		<td>Fired when user mousedown while drawing.</td>
+		<td>Fired when user <code>mousedown</code> while drawing.</td>
 	</tr>
-	<tr id='editable-editable-drawing-mouseup'>
-		<td><code><b>editable.drawing.mouseup</b>
+	<tr id='editable-editable:drawing:mouseup'>
+		<td><code><b>editable:drawing:mouseup</b>
 		<td><code>Event</code></td>
-		<td>Fired when user mouseup while drawing.</td>
+		<td>Fired when user <code>mouseup</code> while drawing.</td>
 	</tr>
-	<tr id='editable-editable-drawing-click'>
-		<td><code><b>editable.drawing.click</b>
+	<tr id='editable-editable:drawing:click'>
+		<td><code><b>editable:drawing:click</b>
 		<td><code><a href='#cancelableevent'>CancelableEvent</a></code></td>
-		<td>Fired when user click while drawing, before any internal action is being processed.</td>
+		<td>Fired when user <code>click</code> while drawing, before any internal action is being processed.</td>
 	</tr>
-	<tr id='editable-editable-drawing-move'>
-		<td><code><b>editable.drawing.move</b>
+	<tr id='editable-editable:drawing:move'>
+		<td><code><b>editable:drawing:move</b>
 		<td><code>Event</code></td>
-		<td>Fired when move mouse while drawing, while dragging a marker, and while dragging a vertex.</td>
+		<td>Fired when <code>move</code> mouse while drawing, while dragging a marker, and while dragging a vertex.</td>
 	</tr>
-	<tr id='editable-editable-dragend'>
-		<td><code><b>editable.dragend</b>
+	<tr id='editable-editable:drawing:clicked'>
+		<td><code><b>editable:drawing:clicked</b>
 		<td><code>Event</code></td>
-		<td>Fired after a path feature has been dragged.</td>
-	</tr>
-	<tr id='editable-editable-drawing-clicked'>
-		<td><code><b>editable.drawing.clicked</b>
-		<td><code>Event</code></td>
-		<td>Fired when user click while drawing, after all internal actions.</td>
+		<td>Fired when user <code>click</code> while drawing, after all internal actions.</td>
 	</tr>
 </tbody></table>
 </section><section data-type='[object Object]'>
@@ -356,70 +356,74 @@ the behaviour: using options, listening to events, or extending.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='editable-editable-vertex-click'>
-		<td><code><b>editable.vertex.click</b>
+	<tr id='editable-editable:vertex:click'>
+		<td><code><b>editable:vertex:click</b>
 		<td><code><a href='#cancelablevertexevent'>CancelableVertexEvent</a></code></td>
-		<td>Fired when a click is issued on a vertex, before any internal action is being processed.</td>
+		<td>Fired when a <code>click</code> is issued on a vertex, before any internal action is being processed.</td>
 	</tr>
-	<tr id='editable-editable-vertex-clicked'>
-		<td><code><b>editable.vertex.clicked</b>
+	<tr id='editable-editable:vertex:clicked'>
+		<td><code><b>editable:vertex:clicked</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
-		<td>Fired when a click is issued on a vertex, after all internal actions.</td>
+		<td>Fired when a <code>click</code> is issued on a vertex, after all internal actions.</td>
 	</tr>
-	<tr id='editable-editable-vertex-rawclick'>
-		<td><code><b>editable.vertex.rawclick</b>
+	<tr id='editable-editable:vertex:rawclick'>
+		<td><code><b>editable:vertex:rawclick</b>
 		<td><code><a href='#cancelablevertexevent'>CancelableVertexEvent</a></code></td>
-		<td>Fired when a click is issued on a vertex without any special key and without being in drawing mode.</td>
+		<td>Fired when a <code>click</code> is issued on a vertex without any special key and without being in drawing mode.</td>
 	</tr>
-	<tr id='editable-editable-vertex-deleted'>
-		<td><code><b>editable.vertex.deleted</b>
+	<tr id='editable-editable:vertex:deleted'>
+		<td><code><b>editable:vertex:deleted</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
 		<td>Fired after a vertex has been deleted by user.</td>
 	</tr>
-	<tr id='editable-editable-vertex-ctrlclick'>
-		<td><code><b>editable.vertex.ctrlclick</b>
+	<tr id='editable-editable:vertex:ctrlclick'>
+		<td><code><b>editable:vertex:ctrlclick</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
-		<td>Fired when a click with ctrlKey is issued on a vertex</td>
+		<td>Fired when a <code>click</code> with <code>ctrlKey</code> is issued on a vertex.</td>
 	</tr>
-	<tr id='editable-editable-vertex-shiftclick'>
-		<td><code><b>editable.vertex.shiftclick</b>
+	<tr id='editable-editable:vertex:shiftclick'>
+		<td><code><b>editable:vertex:shiftclick</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
-		<td>Fired when a click with shiftKey is issued on a vertex</td>
+		<td>Fired when a <code>click</code> with <code>shiftKey</code> is issued on a vertex.</td>
 	</tr>
-	<tr id='editable-editable-vertex-metakeyclick'>
-		<td><code><b>editable.vertex.metakeyclick</b>
+	<tr id='editable-editable:vertex:metakeyclick'>
+		<td><code><b>editable:vertex:metakeyclick</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
-		<td>Fired when a click with metaKey is issued on a vertex</td>
+		<td>Fired when a <code>click</code> with <code>metaKey</code> is issued on a vertex.</td>
 	</tr>
-	<tr id='editable-editable-vertex-altclick'>
-		<td><code><b>editable.vertex.altclick</b>
+	<tr id='editable-editable:vertex:altclick'>
+		<td><code><b>editable:vertex:altclick</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
-		<td>Fired when a click with altKey is issued on a vertex</td>
+		<td>Fired when a <code>click</code> with <code>altKey</code> is issued on a vertex.</td>
 	</tr>
-	<tr id='editable-editable-vertex-contextmenu'>
-		<td><code><b>editable.vertex.contextmenu</b>
+	<tr id='editable-editable:vertex:contextmenu'>
+		<td><code><b>editable:vertex:contextmenu</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
-		<td>Fired when a contextmenu is issued on a vertex.</td>
+		<td>Fired when a <code>contextmenu</code> is issued on a vertex.</td>
 	</tr>
-	<tr id='editable-editable-vertex-mousedown'>
-		<td><code><b>editable.vertex.mousedown</b>
+	<tr id='editable-editable:vertex:mousedown'>
+		<td><code><b>editable:vertex:mousedown</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
-		<td>Fired when user mousedown a vertex.</td>
+		<td>Fired when user <code>mousedown</code> a vertex.</td>
 	</tr>
-	<tr id='editable-editable-vertex-drag'>
-		<td><code><b>editable.vertex.drag</b>
+	<tr id='editable-editable:vertex:drag'>
+		<td><code><b>editable:vertex:drag</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
 		<td>Fired when a vertex is dragged by user.</td>
 	</tr>
-	<tr id='editable-editable-vertex-dragstart'>
-		<td><code><b>editable.vertex.dragstart</b>
+	<tr id='editable-editable:vertex:dragstart'>
+		<td><code><b>editable:vertex:dragstart</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
-		<td>Fired before a vertex is dragged by user.
-Fired after a vertex is dragged by user.</td>
+		<td>Fired before a vertex is dragged by user.</td>
+	</tr>
+	<tr id='editable-editable:vertex:dragend'>
+		<td><code><b>editable:vertex:dragend</b>
+		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
+		<td>Fired after a vertex is dragged by user.</td>
 	</tr>
 </tbody></table>
 </section><section data-type='[object Object]'>
-<h4 id='editable-middlemarker-events'>Middlemarker events</h4>
+<h4 id='editable-middlemarker-events'>MiddleMarker events</h4>
 
 <table><thead>
 	<tr>
@@ -428,10 +432,10 @@ Fired after a vertex is dragged by user.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='editable-editable-middlemarker-mousedown'>
-		<td><code><b>editable.middlemarker.mousedown</b>
+	<tr id='editable-editable:middlemarker:mousedown'>
+		<td><code><b>editable:middlemarker:mousedown</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
-		<td>Fired when user mousedown a middle marker</td>
+		<td>Fired when user <code>mousedown</code> a middle marker.</td>
 	</tr>
 </tbody></table>
 </section><section data-type='[object Object]'>
@@ -444,20 +448,20 @@ Fired after a vertex is dragged by user.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='editable-editable-shape-new'>
-		<td><code><b>editable.shape.new</b>
+	<tr id='editable-editable:shape:new'>
+		<td><code><b>editable:shape:new</b>
 		<td><code><a href='#shapeevent'>ShapeEvent</a></code></td>
-		<td>Fired when a new shape is created in a multi (polygon or polyline).</td>
+		<td>Fired when a new shape is created in a multi (Polygon or Polyline).</td>
 	</tr>
-	<tr id='editable-editable-shape-delete'>
-		<td><code><b>editable.shape.delete</b>
+	<tr id='editable-editable:shape:delete'>
+		<td><code><b>editable:shape:delete</b>
 		<td><code><a href='#cancelableshapeevent'>CancelableShapeEvent</a></code></td>
-		<td>Fired before a new shape is deleted in a multi (polygon or polyline).</td>
+		<td>Fired before a new shape is deleted in a multi (Polygon or Polyline).</td>
 	</tr>
-	<tr id='editable-editable-vertex-deleted'>
-		<td><code><b>editable.vertex.deleted</b>
+	<tr id='editable-editable:shape:deleted'>
+		<td><code><b>editable:shape:deleted</b>
 		<td><code><a href='#shapeevent'>ShapeEvent</a></code></td>
-		<td>Fired after a new shape is deleted in a multi (polygon or polyline).</td>
+		<td>Fired after a new shape is deleted in a multi (Polygon or Polyline).</td>
 	</tr>
 </tbody></table>
 </section>
@@ -481,52 +485,52 @@ instance:
 		<td><code>boolean</code></td>
 		<td>Return true if any drawing action is ongoing.</td>
 	</tr>
-	<tr id='editable-commitdrawing'>
-		<td><code><b>commitDrawing</b>()</nobr></code></td>
-		<td><code></code></td>
-		<td>When you need to stop any ongoing drawing, without needing to know which editor is active..</td>
-	</tr>
 	<tr id='editable-stopdrawing'>
 		<td><code><b>stopDrawing</b>()</nobr></code></td>
+		<td><code></code></td>
+		<td>When you need to stop any ongoing drawing, without needing to know which editor is active.</td>
+	</tr>
+	<tr id='editable-commitdrawing'>
+		<td><code><b>commitDrawing</b>()</nobr></code></td>
 		<td><code></code></td>
 		<td>When you need to commit any ongoing drawing, without needing to know which editor is active.</td>
 	</tr>
 	<tr id='editable-startpolyline'>
 		<td><code><b>startPolyline</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>, <nobr>&lt;hash&gt; <i>options</i></nobr>)</nobr></code></td>
 		<td><code>L.Polyline</code></td>
-		<td>Start drawing a polyline. If latlng is given, a first point will be added. In any case, continuing on user click.
-If <code>options</code> is given, it will be passed to the polyline class constructor.</td>
+		<td>Start drawing a Polyline. If <code>latlng</code> is given, a first point will be added. In any case, continuing on user click.
+If <code>options</code> is given, it will be passed to the Polyline class constructor.</td>
 	</tr>
 	<tr id='editable-startpolygon'>
 		<td><code><b>startPolygon</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>, <nobr>&lt;hash&gt; <i>options</i></nobr>)</nobr></code></td>
 		<td><code>L.Polygon</code></td>
-		<td>Start drawing a polygon. If latlng is given, a first point will be added. In any case, continuing on user click.
-If <code>options</code> is given, it will be passed to the polygon class constructor.</td>
+		<td>Start drawing a Polygon. If <code>latlng</code> is given, a first point will be added. In any case, continuing on user click.
+If <code>options</code> is given, it will be passed to the Polygon class constructor.</td>
 	</tr>
 	<tr id='editable-startmarker'>
 		<td><code><b>startMarker</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>, <nobr>&lt;hash&gt; <i>options</i></nobr>)</nobr></code></td>
 		<td><code>L.Marker</code></td>
-		<td>Start adding a marker. If latlng is given, the marker will be shown first at this point.
-In any case, it will follow the user mouse, and will have a final latlng on next click (or touch).
-If <code>options</code> is given, it will be passed to the marker class constructor.</td>
+		<td>Start adding a Marker. If <code>latlng</code> is given, the Marker will be shown first at this point.
+In any case, it will follow the user mouse, and will have a final <code>latlng</code> on next click (or touch).
+If <code>options</code> is given, it will be passed to the Marker class constructor.</td>
 	</tr>
 	<tr id='editable-startrectangle'>
 		<td><code><b>startRectangle</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>, <nobr>&lt;hash&gt; <i>options</i></nobr>)</nobr></code></td>
 		<td><code>L.Rectangle</code></td>
-		<td>Start drawing a rectangle. If latlng is given, the rectangle anchor will be added. In any case, continuing on user drag.
-If <code>options</code> is given, it will be passed to the rectangle class constructor.</td>
+		<td>Start drawing a Rectangle. If <code>latlng</code> is given, the Rectangle anchor will be added. In any case, continuing on user drag.
+If <code>options</code> is given, it will be passed to the Rectangle class constructor.</td>
 	</tr>
 	<tr id='editable-startcircle'>
 		<td><code><b>startCircle</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>, <nobr>&lt;hash&gt; <i>options</i></nobr>)</nobr></code></td>
 		<td><code>L.Circle</code></td>
-		<td>Start drawing a circle. If latlng is given, the circle anchor will be added. In any case, continuing on user drag.
+		<td>Start drawing a Circle. If <code>latlng</code> is given, the Circle anchor will be added. In any case, continuing on user drag.
 If <code>options</code> is given, it will be passed to the Circle class constructor.</td>
 	</tr>
 </tbody></table>
 </section>
 
 <h2 id='baseeditor'>BaseEditor</h2>
-<p>When editing a feature (marker, polyline…), an editor is attached to it. This
+<p>When editing a feature (Marker, Polyline…), an editor is attached to it. This
 editor basically knows how to handle the edition.</p>
 
 <h3 id='baseeditor-method' class="section">Methods</h3>
@@ -616,7 +620,7 @@ editor basically knows how to handle the edition.</p>
 	<tr id='patheditor-reset'>
 		<td><code><b>reset</b>()</nobr></code></td>
 		<td><code></code></td>
-		<td>Rebuild edit elements (vertex, middlemarker, etc.).</td>
+		<td>Rebuild edit elements (Vertex, MiddleMarker, etc.).</td>
 	</tr>
 	<tr id='patheditor-push'>
 		<td><code><b>push</b>()</nobr></code></td>
@@ -626,33 +630,33 @@ editor basically knows how to handle the edition.</p>
 	<tr id='patheditor-pop'>
 		<td><code><b>pop</b>()</nobr></code></td>
 		<td><code>L.LatLng or null</code></td>
-		<td>Programatically remove last point (if any) while drawing.</td>
+		<td>Programmatically remove last point (if any) while drawing.</td>
 	</tr>
 	<tr id='patheditor-newshape'>
 		<td><code><b>newShape</b>(<nobr>&lt;L.LatLng&gt; <i>latlng?</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Add a new shape (polyline, polygon) in a multi, and setup up drawing tools to draw it;
+		<td>Add a new shape (Polyline, Polygon) in a multi, and setup up drawing tools to draw it;
 if optional <code>latlng</code> is given, start a path at this point.</td>
 	</tr>
 	<tr id='patheditor-deleteshapeat'>
 		<td><code><b>deleteShapeAt</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>)</nobr></code></td>
 		<td><code>Array</code></td>
-		<td>Remove a path shape at the given latlng.</td>
+		<td>Remove a path shape at the given <code>latlng</code>.</td>
 	</tr>
 	<tr id='patheditor-appendshape'>
 		<td><code><b>appendShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Append a new shape to the polygon or polyline.</td>
+		<td>Append a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='patheditor-prependshape'>
 		<td><code><b>prependShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Prepend a new shape to the polygon or polyline.</td>
+		<td>Prepend a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='patheditor-insertshape'>
 		<td><code><b>insertShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>, <nobr>&lt;int&gt; <i>index</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Insert a new shape to the polygon or polyline at given index (default is to append)</td>
+		<td>Insert a new shape to the Polygon or Polyline at given index (default is to append).</td>
 	</tr>
 </tbody></table>
 </section>
@@ -716,7 +720,7 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	<tr id='polylineeditor-splitshape'>
 		<td><code><b>splitShape</b>(<nobr>&lt;Array&gt; <i>latlngs?</i></nobr>, <nobr>&lt;int&gt; <i>index</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Split the given latlngs shape at index <code>index</code> and integrate new shape in instance latlngs.</td>
+		<td>Split the given <code>latlngs</code> shape at index <code>index</code> and integrate new shape in instance <code>latlngs</code>.</td>
 	</tr>
 </tbody></table>
 </section>
@@ -737,7 +741,7 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	<tr id='polylineeditor-reset'>
 		<td><code><b>reset</b>()</nobr></code></td>
 		<td><code></code></td>
-		<td>Rebuild edit elements (vertex, middlemarker, etc.).</td>
+		<td>Rebuild edit elements (Vertex, MiddleMarker, etc.).</td>
 	</tr>
 	<tr id='polylineeditor-push'>
 		<td><code><b>push</b>()</nobr></code></td>
@@ -747,33 +751,33 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	<tr id='polylineeditor-pop'>
 		<td><code><b>pop</b>()</nobr></code></td>
 		<td><code>L.LatLng or null</code></td>
-		<td>Programatically remove last point (if any) while drawing.</td>
+		<td>Programmatically remove last point (if any) while drawing.</td>
 	</tr>
 	<tr id='polylineeditor-newshape'>
 		<td><code><b>newShape</b>(<nobr>&lt;L.LatLng&gt; <i>latlng?</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Add a new shape (polyline, polygon) in a multi, and setup up drawing tools to draw it;
+		<td>Add a new shape (Polyline, Polygon) in a multi, and setup up drawing tools to draw it;
 if optional <code>latlng</code> is given, start a path at this point.</td>
 	</tr>
 	<tr id='polylineeditor-deleteshapeat'>
 		<td><code><b>deleteShapeAt</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>)</nobr></code></td>
 		<td><code>Array</code></td>
-		<td>Remove a path shape at the given latlng.</td>
+		<td>Remove a path shape at the given <code>latlng</code>.</td>
 	</tr>
 	<tr id='polylineeditor-appendshape'>
 		<td><code><b>appendShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Append a new shape to the polygon or polyline.</td>
+		<td>Append a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='polylineeditor-prependshape'>
 		<td><code><b>prependShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Prepend a new shape to the polygon or polyline.</td>
+		<td>Prepend a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='polylineeditor-insertshape'>
 		<td><code><b>insertShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>, <nobr>&lt;int&gt; <i>index</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Insert a new shape to the polygon or polyline at given index (default is to append)</td>
+		<td>Insert a new shape to the Polygon or Polyline at given index (default is to append).</td>
 	</tr>
 </tbody></table>
 </section></div>
@@ -826,9 +830,9 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	</tr>
 	</thead><tbody>
 	<tr id='polygoneditor-newhole'>
-		<td><code><b>newHole</b>(<nobr>&lt;Array&gt; <i>latlngs?</i></nobr>, <nobr>&lt;int&gt; <i>index</i></nobr>)</nobr></code></td>
+		<td><code><b>newHole</b>(<nobr>&lt;L.LatLng&gt; <i>latlng?</i></nobr>, <nobr>&lt;int&gt; <i>index</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Set up drawing tools for creating a new hole on the polygon. If the latlng param is given, a first point is created.</td>
+		<td>Set up drawing tools for creating a new hole on the Polygon. If the <code>latlng</code> param is given, a first point is created.</td>
 	</tr>
 </tbody></table>
 </section>
@@ -849,7 +853,7 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	<tr id='polygoneditor-reset'>
 		<td><code><b>reset</b>()</nobr></code></td>
 		<td><code></code></td>
-		<td>Rebuild edit elements (vertex, middlemarker, etc.).</td>
+		<td>Rebuild edit elements (Vertex, MiddleMarker, etc.).</td>
 	</tr>
 	<tr id='polygoneditor-push'>
 		<td><code><b>push</b>()</nobr></code></td>
@@ -859,33 +863,33 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	<tr id='polygoneditor-pop'>
 		<td><code><b>pop</b>()</nobr></code></td>
 		<td><code>L.LatLng or null</code></td>
-		<td>Programatically remove last point (if any) while drawing.</td>
+		<td>Programmatically remove last point (if any) while drawing.</td>
 	</tr>
 	<tr id='polygoneditor-newshape'>
 		<td><code><b>newShape</b>(<nobr>&lt;L.LatLng&gt; <i>latlng?</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Add a new shape (polyline, polygon) in a multi, and setup up drawing tools to draw it;
+		<td>Add a new shape (Polyline, Polygon) in a multi, and setup up drawing tools to draw it;
 if optional <code>latlng</code> is given, start a path at this point.</td>
 	</tr>
 	<tr id='polygoneditor-deleteshapeat'>
 		<td><code><b>deleteShapeAt</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>)</nobr></code></td>
 		<td><code>Array</code></td>
-		<td>Remove a path shape at the given latlng.</td>
+		<td>Remove a path shape at the given <code>latlng</code>.</td>
 	</tr>
 	<tr id='polygoneditor-appendshape'>
 		<td><code><b>appendShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Append a new shape to the polygon or polyline.</td>
+		<td>Append a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='polygoneditor-prependshape'>
 		<td><code><b>prependShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Prepend a new shape to the polygon or polyline.</td>
+		<td>Prepend a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='polygoneditor-insertshape'>
 		<td><code><b>insertShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>, <nobr>&lt;int&gt; <i>index</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Insert a new shape to the polygon or polyline at given index (default is to append)</td>
+		<td>Insert a new shape to the Polygon or Polyline at given index (default is to append).</td>
 	</tr>
 </tbody></table>
 </section></div>
@@ -945,7 +949,7 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	<tr id='rectangleeditor-reset'>
 		<td><code><b>reset</b>()</nobr></code></td>
 		<td><code></code></td>
-		<td>Rebuild edit elements (vertex, middlemarker, etc.).</td>
+		<td>Rebuild edit elements (Vertex, MiddleMarker, etc.).</td>
 	</tr>
 	<tr id='rectangleeditor-push'>
 		<td><code><b>push</b>()</nobr></code></td>
@@ -955,33 +959,33 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	<tr id='rectangleeditor-pop'>
 		<td><code><b>pop</b>()</nobr></code></td>
 		<td><code>L.LatLng or null</code></td>
-		<td>Programatically remove last point (if any) while drawing.</td>
+		<td>Programmatically remove last point (if any) while drawing.</td>
 	</tr>
 	<tr id='rectangleeditor-newshape'>
 		<td><code><b>newShape</b>(<nobr>&lt;L.LatLng&gt; <i>latlng?</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Add a new shape (polyline, polygon) in a multi, and setup up drawing tools to draw it;
+		<td>Add a new shape (Polyline, Polygon) in a multi, and setup up drawing tools to draw it;
 if optional <code>latlng</code> is given, start a path at this point.</td>
 	</tr>
 	<tr id='rectangleeditor-deleteshapeat'>
 		<td><code><b>deleteShapeAt</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>)</nobr></code></td>
 		<td><code>Array</code></td>
-		<td>Remove a path shape at the given latlng.</td>
+		<td>Remove a path shape at the given <code>latlng</code>.</td>
 	</tr>
 	<tr id='rectangleeditor-appendshape'>
 		<td><code><b>appendShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Append a new shape to the polygon or polyline.</td>
+		<td>Append a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='rectangleeditor-prependshape'>
 		<td><code><b>prependShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Prepend a new shape to the polygon or polyline.</td>
+		<td>Prepend a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='rectangleeditor-insertshape'>
 		<td><code><b>insertShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>, <nobr>&lt;int&gt; <i>index</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Insert a new shape to the polygon or polyline at given index (default is to append)</td>
+		<td>Insert a new shape to the Polygon or Polyline at given index (default is to append).</td>
 	</tr>
 </tbody></table>
 </section></div>
@@ -1041,7 +1045,7 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	<tr id='circleeditor-reset'>
 		<td><code><b>reset</b>()</nobr></code></td>
 		<td><code></code></td>
-		<td>Rebuild edit elements (vertex, middlemarker, etc.).</td>
+		<td>Rebuild edit elements (Vertex, MiddleMarker, etc.).</td>
 	</tr>
 	<tr id='circleeditor-push'>
 		<td><code><b>push</b>()</nobr></code></td>
@@ -1051,33 +1055,33 @@ if optional <code>latlng</code> is given, start a path at this point.</td>
 	<tr id='circleeditor-pop'>
 		<td><code><b>pop</b>()</nobr></code></td>
 		<td><code>L.LatLng or null</code></td>
-		<td>Programatically remove last point (if any) while drawing.</td>
+		<td>Programmatically remove last point (if any) while drawing.</td>
 	</tr>
 	<tr id='circleeditor-newshape'>
 		<td><code><b>newShape</b>(<nobr>&lt;L.LatLng&gt; <i>latlng?</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Add a new shape (polyline, polygon) in a multi, and setup up drawing tools to draw it;
+		<td>Add a new shape (Polyline, Polygon) in a multi, and setup up drawing tools to draw it;
 if optional <code>latlng</code> is given, start a path at this point.</td>
 	</tr>
 	<tr id='circleeditor-deleteshapeat'>
 		<td><code><b>deleteShapeAt</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>)</nobr></code></td>
 		<td><code>Array</code></td>
-		<td>Remove a path shape at the given latlng.</td>
+		<td>Remove a path shape at the given <code>latlng</code>.</td>
 	</tr>
 	<tr id='circleeditor-appendshape'>
 		<td><code><b>appendShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Append a new shape to the polygon or polyline.</td>
+		<td>Append a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='circleeditor-prependshape'>
 		<td><code><b>prependShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Prepend a new shape to the polygon or polyline.</td>
+		<td>Prepend a new shape to the Polygon or Polyline.</td>
 	</tr>
 	<tr id='circleeditor-insertshape'>
 		<td><code><b>insertShape</b>(<nobr>&lt;Array&gt; <i>shape</i></nobr>, <nobr>&lt;int&gt; <i>index</i></nobr>)</nobr></code></td>
 		<td><code></code></td>
-		<td>Insert a new shape to the polygon or polyline at given index (default is to append)</td>
+		<td>Insert a new shape to the Polygon or Polyline at given index (default is to append).</td>
 	</tr>
 </tbody></table>
 </section></div>
@@ -1134,7 +1138,7 @@ instance when listening for events like <code>editable:vertex:ctrlclick</code>.
 	<tr id='vertexmarker-delete'>
 		<td><code><b>delete</b>()</nobr></code></td>
 		<td><code></code></td>
-		<td>Delete a vertex and the related latlng.</td>
+		<td>Delete a vertex and the related LatLng.</td>
 	</tr>
 	<tr id='vertexmarker-getindex'>
 		<td><code><b>getIndex</b>()</nobr></code></td>

--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -62,39 +62,39 @@
             zIndex: 1000,
 
             // 🍂option polygonClass: class = L.Polygon
-            // Class to be used when creating a new Polygon
+            // Class to be used when creating a new Polygon.
             polygonClass: L.Polygon,
 
             // 🍂option polylineClass: class = L.Polyline
-            // Class to be used when creating a new Polyline
+            // Class to be used when creating a new Polyline.
             polylineClass: L.Polyline,
 
             // 🍂option markerClass: class = L.Marker
-            // Class to be used when creating a new Marker
+            // Class to be used when creating a new Marker.
             markerClass: L.Marker,
 
             // 🍂option rectangleClass: class = L.Rectangle
-            // Class to be used when creating a new Rectangle
+            // Class to be used when creating a new Rectangle.
             rectangleClass: L.Rectangle,
 
             // 🍂option circleClass: class = L.Circle
-            // Class to be used when creating a new Circle
+            // Class to be used when creating a new Circle.
             circleClass: L.Circle,
 
             // 🍂option drawingCSSClass: string = 'leaflet-editable-drawing'
-            // CSS class to be added to the map container while drawing
+            // CSS class to be added to the map container while drawing.
             drawingCSSClass: 'leaflet-editable-drawing',
 
             // 🍂option drawingCursor: const = 'crosshair'
-            // cursor mode set to the map while drawing
+            // Cursor mode set to the map while drawing.
             drawingCursor: 'crosshair',
 
             // 🍂option editLayer: Layer = new L.LayerGroup()
-            // Layer used to store edit tools (vertex, line guide…)
+            // Layer used to store edit tools (vertex, line guide…).
             editLayer: undefined,
 
             // 🍂option featuresLayer: Layer = new L.LayerGroup()
-            // Default layer used to store drawn features (marker, polyline…)
+            // Default layer used to store drawn features (Marker, Polyline…).
             featuresLayer: undefined,
 
             // 🍂option polylineEditorClass: class = PolylineEditor
@@ -281,7 +281,7 @@
         },
 
         // 🍂method stopDrawing()
-        // When you need to stop any ongoing drawing, without needing to know which editor is active..
+        // When you need to stop any ongoing drawing, without needing to know which editor is active.
         stopDrawing: function () {
             this.unregisterForDrawing();
         },
@@ -298,8 +298,8 @@
         },
 
         // 🍂method startPolyline(latlng: L.LatLng, options: hash): L.Polyline
-        // Start drawing a polyline. If latlng is given, a first point will be added. In any case, continuing on user click.
-        // If `options` is given, it will be passed to the polyline class constructor.
+        // Start drawing a Polyline. If `latlng` is given, a first point will be added. In any case, continuing on user click.
+        // If `options` is given, it will be passed to the Polyline class constructor.
         startPolyline: function (latlng, options) {
             var line = this.createPolyline([], options);
             line.enableEdit(this.map).newShape(latlng);
@@ -307,8 +307,8 @@
         },
 
         // 🍂method startPolygon(latlng: L.LatLng, options: hash): L.Polygon
-        // Start drawing a polygon. If latlng is given, a first point will be added. In any case, continuing on user click.
-        // If `options` is given, it will be passed to the polygon class constructor.
+        // Start drawing a Polygon. If `latlng` is given, a first point will be added. In any case, continuing on user click.
+        // If `options` is given, it will be passed to the Polygon class constructor.
         startPolygon: function (latlng, options) {
             var polygon = this.createPolygon([], options);
             polygon.enableEdit(this.map).newShape(latlng);
@@ -316,9 +316,9 @@
         },
 
         // 🍂method startMarker(latlng: L.LatLng, options: hash): L.Marker
-        // Start adding a marker. If latlng is given, the marker will be shown first at this point.
-        // In any case, it will follow the user mouse, and will have a final latlng on next click (or touch).
-        // If `options` is given, it will be passed to the marker class constructor.
+        // Start adding a Marker. If `latlng` is given, the Marker will be shown first at this point.
+        // In any case, it will follow the user mouse, and will have a final `latlng` on next click (or touch).
+        // If `options` is given, it will be passed to the Marker class constructor.
         startMarker: function (latlng, options) {
             latlng = latlng || this.map.getCenter().clone();
             var marker = this.createMarker(latlng, options);
@@ -327,8 +327,8 @@
         },
 
         // 🍂method startRectangle(latlng: L.LatLng, options: hash): L.Rectangle
-        // Start drawing a rectangle. If latlng is given, the rectangle anchor will be added. In any case, continuing on user drag.
-        // If `options` is given, it will be passed to the rectangle class constructor.
+        // Start drawing a Rectangle. If `latlng` is given, the Rectangle anchor will be added. In any case, continuing on user drag.
+        // If `options` is given, it will be passed to the Rectangle class constructor.
         startRectangle: function(latlng, options) {
             var corner = latlng || L.latLng([0, 0]);
             var bounds = new L.LatLngBounds(corner, corner);
@@ -338,7 +338,7 @@
         },
 
         // 🍂method startCircle(latlng: L.LatLng, options: hash): L.Circle
-        // Start drawing a circle. If latlng is given, the circle anchor will be added. In any case, continuing on user drag.
+        // Start drawing a Circle. If `latlng` is given, the Circle anchor will be added. In any case, continuing on user drag.
         // If `options` is given, it will be passed to the Circle class constructor.
         startCircle: function (latlng, options) {
             latlng = latlng || this.map.getCenter().clone();
@@ -412,7 +412,7 @@
         // 🍂namespace Map
         // 🍂section Map Options
         // 🍂option editToolsClass: class = L.Editable
-        // Class to be used as vertex, for path editing
+        // Class to be used as vertex, for path editing.
         editToolsClass: L.Editable,
 
         // 🍂option editable: boolean = false
@@ -548,7 +548,7 @@
         },
 
         // 🍂method delete()
-        // Delete a vertex and the related latlng.
+        // Delete a vertex and the related LatLng.
         delete: function () {
             var next = this.getNext();  // Compute before changing latlng
             this.latlngs.splice(this.getIndex(), 1);
@@ -634,7 +634,7 @@
 
         // 🍂namespace Editable
         // 🍂option vertexMarkerClass: class = VertexMarker
-        // Class to be used as vertex, for path editing
+        // Class to be used as vertex, for path editing.
         vertexMarkerClass: L.Editable.VertexMarker
 
     });
@@ -751,7 +751,7 @@
     });
 
     // 🍂namespace Editable; 🍂class BaseEditor; 🍂aka L.Editable.BaseEditor
-    // When editing a feature (marker, polyline…), an editor is attached to it. This
+    // When editing a feature (Marker, Polyline…), an editor is attached to it. This
     // editor basically knows how to handle the edition.
     L.Editable.BaseEditor = L.Handler.extend({
 
@@ -812,21 +812,21 @@
 
         onEnable: function () {
             // 🍂namespace Editable
-            // 🍂event editable.enable: Event
+            // 🍂event editable:enable: Event
             // Fired when an existing feature is ready to be edited.
             this.fireAndForward('editable:enable');
         },
 
         onDisable: function () {
             // 🍂namespace Editable
-            // 🍂event editable.disable: Event
+            // 🍂event editable:disable: Event
             // Fired when an existing feature is not ready anymore to be edited.
             this.fireAndForward('editable:disable');
         },
 
         onEditing: function () {
             // 🍂namespace Editable
-            // 🍂event editable.editing: Event
+            // 🍂event editable:editing: Event
             // Fired as soon as any change is made to the feature geometry.
             this.fireAndForward('editable:editing');
         },
@@ -834,7 +834,7 @@
         onStartDrawing: function () {
             // 🍂namespace Editable
             // 🍂section Drawing events
-            // 🍂event editable.drawing.start: Event
+            // 🍂event editable:drawing:start: Event
             // Fired when a feature is to be drawn.
             this.fireAndForward('editable:drawing:start');
         },
@@ -842,7 +842,7 @@
         onEndDrawing: function () {
             // 🍂namespace Editable
             // 🍂section Drawing events
-            // 🍂event editable.drawing.end: Event
+            // 🍂event editable:drawing:end: Event
             // Fired when a feature is not drawn anymore.
             this.fireAndForward('editable:drawing:end');
         },
@@ -850,7 +850,7 @@
         onCancelDrawing: function () {
             // 🍂namespace Editable
             // 🍂section Drawing events
-            // 🍂event editable.drawing.cancel: Event
+            // 🍂event editable:drawing:cancel: Event
             // Fired when user cancel drawing while a feature is being drawn.
             this.fireAndForward('editable:drawing:cancel');
         },
@@ -858,7 +858,7 @@
         onCommitDrawing: function (e) {
             // 🍂namespace Editable
             // 🍂section Drawing events
-            // 🍂event editable.drawing.commit: Event
+            // 🍂event editable:drawing:commit: Event
             // Fired when user finish drawing a feature.
             this.fireAndForward('editable:drawing:commit', e);
         },
@@ -866,16 +866,16 @@
         onDrawingMouseDown: function (e) {
             // 🍂namespace Editable
             // 🍂section Drawing events
-            // 🍂event editable.drawing.mousedown: Event
-            // Fired when user mousedown while drawing.
+            // 🍂event editable:drawing:mousedown: Event
+            // Fired when user `mousedown` while drawing.
             this.fireAndForward('editable:drawing:mousedown', e);
         },
 
         onDrawingMouseUp: function (e) {
             // 🍂namespace Editable
             // 🍂section Drawing events
-            // 🍂event editable.drawing.mouseup: Event
-            // Fired when user mouseup while drawing.
+            // 🍂event editable:drawing:mouseup: Event
+            // Fired when user `mouseup` while drawing.
             this.fireAndForward('editable:drawing:mouseup', e);
         },
 
@@ -910,8 +910,8 @@
             L.Editable.makeCancellable(e);
             // 🍂namespace Editable
             // 🍂section Drawing events
-            // 🍂event editable.drawing.click: CancelableEvent
-            // Fired when user click while drawing, before any internal action is being processed.
+            // 🍂event editable:drawing:click: CancelableEvent
+            // Fired when user `click` while drawing, before any internal action is being processed.
             this.fireAndForward('editable:drawing:click', e);
             if (e._cancelled) return;
             if (!this.isConnected()) this.connect(e);
@@ -930,8 +930,8 @@
         onMove: function (e) {
             // 🍂namespace Editable
             // 🍂section Drawing events
-            // 🍂event editable.drawing.move: Event
-            // Fired when move mouse while drawing, while dragging a marker, and while dragging a vertex.
+            // 🍂event editable:drawing:move: Event
+            // Fired when `move` mouse while drawing, while dragging a marker, and while dragging a vertex.
             this.fireAndForward('editable:drawing:move', e);
         },
 
@@ -951,7 +951,7 @@
         onDragStart: function (e) {
             this.onEditing();
             // 🍂namespace Editable
-            // 🍂event editable.dragstart: Event
+            // 🍂event editable:dragstart: Event
             // Fired before a path feature is dragged.
             this.fireAndForward('editable:dragstart', e);
         },
@@ -959,15 +959,14 @@
         onDrag: function (e) {
             this.onMove(e);
             // 🍂namespace Editable
-            // 🍂event editable.drag: Event
+            // 🍂event editable:drag: Event
             // Fired when a path feature is being dragged.
             this.fireAndForward('editable:drag', e);
         },
 
         onDragEnd: function (e) {
             // 🍂namespace Editable
-            // 🍂section Drawing events
-            // 🍂event editable.dragend: Event
+            // 🍂event editable:dragend: Event
             // Fired after a path feature has been dragged.
             this.fireAndForward('editable:dragend', e);
         }
@@ -987,8 +986,8 @@
         processDrawingClick: function (e) {
             // 🍂namespace Editable
             // 🍂section Drawing events
-            // 🍂event editable.drawing.clicked: Event
-            // Fired when user click while drawing, after all internal actions.
+            // 🍂event editable:drawing:clicked: Event
+            // Fired when user `click` while drawing, after all internal actions.
             this.fireAndForward('editable:drawing:clicked', e);
             this.commitDrawing(e);
         },
@@ -1028,7 +1027,7 @@
         },
 
         // 🍂method reset()
-        // Rebuild edit elements (vertex, middlemarker, etc.).
+        // Rebuild edit elements (Vertex, MiddleMarker, etc.).
         reset: function () {
             this.editLayer.clearLayers();
             this.initVertexMarkers();
@@ -1059,8 +1058,8 @@
             L.Editable.makeCancellable(e);
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.click: CancelableVertexEvent
-            // Fired when a click is issued on a vertex, before any internal action is being processed.
+            // 🍂event editable:vertex:click: CancelableVertexEvent
+            // Fired when a `click` is issued on a vertex, before any internal action is being processed.
             this.fireAndForward('editable:vertex:click', e);
             if (e._cancelled) return;
             if (this.tools.drawing() && this.tools._drawingEditor !== this) return;
@@ -1084,8 +1083,8 @@
             }
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.clicked: VertexEvent
-            // Fired when a click is issued on a vertex, after all internal actions.
+            // 🍂event editable:vertex:clicked: VertexEvent
+            // Fired when a `click` is issued on a vertex, after all internal actions.
             this.fireAndForward('editable:vertex:clicked', e);
             if (commit) this.commitDrawing(e);
         },
@@ -1093,8 +1092,8 @@
         onVertexRawMarkerClick: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.rawclick: CancelableVertexEvent
-            // Fired when a click is issued on a vertex without any special key and without being in drawing mode.
+            // 🍂event editable:vertex:rawclick: CancelableVertexEvent
+            // Fired when a `click` is issued on a vertex without any special key and without being in drawing mode.
             this.fireAndForward('editable:vertex:rawclick', e);
             if (e._cancelled) return;
             if (!this.vertexCanBeDeleted(e.vertex)) return;
@@ -1108,7 +1107,7 @@
         onVertexDeleted: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.deleted: VertexEvent
+            // 🍂event editable:vertex:deleted: VertexEvent
             // Fired after a vertex has been deleted by user.
             this.fireAndForward('editable:vertex:deleted', e);
         },
@@ -1116,56 +1115,56 @@
         onVertexMarkerCtrlClick: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.ctrlclick: VertexEvent
-            // Fired when a click with ctrlKey is issued on a vertex
+            // 🍂event editable:vertex:ctrlclick: VertexEvent
+            // Fired when a `click` with `ctrlKey` is issued on a vertex.
             this.fireAndForward('editable:vertex:ctrlclick', e);
         },
 
         onVertexMarkerShiftClick: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.shiftclick: VertexEvent
-            // Fired when a click with shiftKey is issued on a vertex
+            // 🍂event editable:vertex:shiftclick: VertexEvent
+            // Fired when a `click` with `shiftKey` is issued on a vertex.
             this.fireAndForward('editable:vertex:shiftclick', e);
         },
 
         onVertexMarkerMetaKeyClick: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.metakeyclick: VertexEvent
-            // Fired when a click with metaKey is issued on a vertex
+            // 🍂event editable:vertex:metakeyclick: VertexEvent
+            // Fired when a `click` with `metaKey` is issued on a vertex.
             this.fireAndForward('editable:vertex:metakeyclick', e);
         },
 
         onVertexMarkerAltClick: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.altclick: VertexEvent
-            // Fired when a click with altKey is issued on a vertex
+            // 🍂event editable:vertex:altclick: VertexEvent
+            // Fired when a `click` with `altKey` is issued on a vertex.
             this.fireAndForward('editable:vertex:altclick', e);
         },
 
         onVertexMarkerContextMenu: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.contextmenu: VertexEvent
-            // Fired when a contextmenu is issued on a vertex.
+            // 🍂event editable:vertex:contextmenu: VertexEvent
+            // Fired when a `contextmenu` is issued on a vertex.
             this.fireAndForward('editable:vertex:contextmenu', e);
         },
 
         onVertexMarkerMouseDown: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.mousedown: VertexEvent
-            // Fired when user mousedown a vertex.
+            // 🍂event editable:vertex:mousedown: VertexEvent
+            // Fired when user `mousedown` a vertex.
             this.fireAndForward('editable:vertex:mousedown', e);
         },
 
         onMiddleMarkerMouseDown: function (e) {
             // 🍂namespace Editable
-            // 🍂section Middlemarker events
-            // 🍂event editable.middlemarker.mousedown: VertexEvent
-            // Fired when user mousedown a middle marker
+            // 🍂section MiddleMarker events
+            // 🍂event editable:middlemarker:mousedown: VertexEvent
+            // Fired when user `mousedown` a middle marker.
             this.fireAndForward('editable:middlemarker:mousedown', e);
         },
 
@@ -1174,7 +1173,7 @@
             if (this.feature._bounds) this.extendBounds(e);
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.drag: VertexEvent
+            // 🍂event editable:vertex:drag: VertexEvent
             // Fired when a vertex is dragged by user.
             this.fireAndForward('editable:vertex:drag', e);
         },
@@ -1182,7 +1181,7 @@
         onVertexMarkerDragStart: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.dragstart: VertexEvent
+            // 🍂event editable:vertex:dragstart: VertexEvent
             // Fired before a vertex is dragged by user.
             this.fireAndForward('editable:vertex:dragstart', e);
         },
@@ -1190,7 +1189,7 @@
         onVertexMarkerDragEnd: function (e) {
             // 🍂namespace Editable
             // 🍂section Vertex events
-            // 🍂event editable.vertex.dragstart: VertexEvent
+            // 🍂event editable:vertex:dragend: VertexEvent
             // Fired after a vertex is dragged by user.
             this.fireAndForward('editable:vertex:dragend', e);
         },
@@ -1250,7 +1249,7 @@
         },
 
         // 🍂method pop(): L.LatLng or null
-        // Programatically remove last point (if any) while drawing.
+        // Programmatically remove last point (if any) while drawing.
         pop: function () {
             if (this._drawnLatLngs.length <= 1) return;
             var latlng;
@@ -1284,7 +1283,7 @@
 
         // 🍂namespace PathEditor
         // 🍂method newShape(latlng?: L.LatLng)
-        // Add a new shape (polyline, polygon) in a multi, and setup up drawing tools to draw it;
+        // Add a new shape (Polyline, Polygon) in a multi, and setup up drawing tools to draw it;
         // if optional `latlng` is given, start a path at this point.
         newShape: function (latlng) {
             var shape = this.addNewEmptyShape();
@@ -1293,8 +1292,8 @@
             this.startDrawingForward();
             // 🍂namespace Editable
             // 🍂section Shape events
-            // 🍂event editable.shape.new: ShapeEvent
-            // Fired when a new shape is created in a multi (polygon or polyline).
+            // 🍂event editable:shape:new: ShapeEvent
+            // Fired when a new shape is created in a multi (Polygon or Polyline).
             this.fireAndForward('editable:shape:new', {shape: shape});
             if (latlng) this.newPointForward(latlng);
         },
@@ -1304,8 +1303,8 @@
             L.Editable.makeCancellable(e);
             // 🍂namespace Editable
             // 🍂section Shape events
-            // 🍂event editable.shape.delete: CancelableShapeEvent
-            // Fired before a new shape is deleted in a multi (polygon or polyline).
+            // 🍂event editable:shape:delete: CancelableShapeEvent
+            // Fired before a new shape is deleted in a multi (Polygon or Polyline).
             this.fireAndForward('editable:shape:delete', e);
             if (e._cancelled) return;
             shape = this._deleteShape(shape, latlngs);
@@ -1315,8 +1314,8 @@
             this.reset();
             // 🍂namespace Editable
             // 🍂section Shape events
-            // 🍂event editable.vertex.deleted: ShapeEvent
-            // Fired after a new shape is deleted in a multi (polygon or polyline).
+            // 🍂event editable:shape:deleted: ShapeEvent
+            // Fired after a new shape is deleted in a multi (Polygon or Polyline).
             this.fireAndForward('editable:shape:deleted', {shape: shape});
             return shape;
         },
@@ -1345,26 +1344,26 @@
 
         // 🍂namespace PathEditor
         // 🍂method deleteShapeAt(latlng: L.LatLng): Array
-        // Remove a path shape at the given latlng.
+        // Remove a path shape at the given `latlng`.
         deleteShapeAt: function (latlng) {
             var shape = this.feature.shapeAt(latlng);
             if (shape) return this.deleteShape(shape);
         },
 
         // 🍂method appendShape(shape: Array)
-        // Append a new shape to the polygon or polyline.
+        // Append a new shape to the Polygon or Polyline.
         appendShape: function (shape) {
             this.insertShape(shape);
         },
 
         // 🍂method prependShape(shape: Array)
-        // Prepend a new shape to the polygon or polyline.
+        // Prepend a new shape to the Polygon or Polyline.
         prependShape: function (shape) {
             this.insertShape(shape, 0);
         },
 
         // 🍂method insertShape(shape: Array, index: int)
-        // Insert a new shape to the polygon or polyline at given index (default is to append)
+        // Insert a new shape to the Polygon or Polyline at given index (default is to append).
         insertShape: function (shape, index) {
             this.ensureMulti();
             shape = this.formatShape(shape);
@@ -1453,7 +1452,7 @@
         },
 
         // 🍂method splitShape(latlngs?: Array, index: int)
-        // Split the given latlngs shape at index `index` and integrate new shape in instance latlngs.
+        // Split the given `latlngs` shape at index `index` and integrate new shape in instance `latlngs`.
         splitShape: function (shape, index) {
             if (!index || index >= shape.length - 1) return;
             this.ensureMulti();
@@ -1492,8 +1491,8 @@
             return holes;
         },
 
-        // 🍂method newHole(latlngs?: Array, index: int)
-        // Set up drawing tools for creating a new hole on the polygon. If the latlng param is given, a first point is created.
+        // 🍂method newHole(latlng?: L.LatLng, index: int)
+        // Set up drawing tools for creating a new hole on the Polygon. If the `latlng` param is given, a first point is created.
         newHole: function (latlng) {
             var holes = this.addNewEmptyHole(latlng);
             if (!holes) return;


### PR DESCRIPTION
There was some issues with `Leafdoc` generated API reference that did not work with `:` for namespacing events https://github.com/Leaflet/Leafdoc/pull/19. Fixed now in `Leafdoc` and in `Leaflet.Editable`. Also did some other small tweaks to documentation.