### PR TITLE
fix: editable forces leaflet path objects to be draggable

### DIFF
--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -795,7 +795,6 @@
 
         onFeatureAdd: function () {
             this.tools.editLayer.addLayer(this.editLayer);
-            if (this.feature.dragging) this.feature.dragging.enable();
         },
 
         hasMiddleMarkers: function () {


### PR DESCRIPTION
Leaflet.Editable forces leaflet path objects to be draggable if a draggable handler is registered, whether draggable is set to true or false.

fixes #151 