### PR TITLE
Add mouseover and mouseout events to VertexMarker

### DIFF
--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -487,6 +487,8 @@
             this.on('click', this.onClick);
             this.on('contextmenu', this.onContextMenu);
             this.on('mousedown touchstart', this.onMouseDown);
+            this.on('mouseover', this.onMouseOver);
+            this.on('mouseout', this.onMouseOut);
             this.addMiddleMarkers();
         },
 
@@ -500,6 +502,8 @@
             this.off('click', this.onClick);
             this.off('contextmenu', this.onContextMenu);
             this.off('mousedown touchstart', this.onMouseDown);
+            this.off('mouseover', this.onMouseOver);
+            this.off('mouseout', this.onMouseOut);
             L.Marker.prototype.onRemove.call(this, map);
         },
 
@@ -545,6 +549,16 @@
         onMouseDown: function (e) {
             e.vertex = this;
             this.editor.onVertexMarkerMouseDown(e);
+        },
+
+        onMouseOver: function (e) {
+            e.vertex = this;
+            this.editor.onVertexMarkerMouseOver(e);
+        },
+
+        onMouseOut: function (e) {
+            e.vertex = this;
+            this.editor.onVertexMarkerMouseOut(e);
         },
 
         // 🍂method delete()
@@ -1165,6 +1179,22 @@
             // 🍂event editable:vertex:mousedown: VertexEvent
             // Fired when user `mousedown` a vertex.
             this.fireAndForward('editable:vertex:mousedown', e);
+        },
+
+        onVertexMarkerMouseOver: function (e) {
+            // 🍂namespace Editable
+            // 🍂section Vertex events
+            // 🍂event editable:vertex:mouseover: VertexEvent
+            // Fired when a user's mouse enters the vertex
+            this.fireAndForward('editable:vertex:mouseover', e);
+        },
+
+        onVertexMarkerMouseOut: function (e) {
+            // 🍂namespace Editable
+            // 🍂section Vertex events
+            // 🍂event editable:vertex:mouseout: VertexEvent
+            // Fired when a user's mouse leaves the vertex
+            this.fireAndForward('editable:vertex:mouseout', e);
         },
 
         onMiddleMarkerMouseDown: function (e) {

--- a/test/PolygonEditor.js
+++ b/test/PolygonEditor.js
@@ -663,6 +663,31 @@ describe('L.PolygonEditor', function() {
             layer.remove();
         });
 
+        it('should fire editable:drawing:mouseover after hovering over vertex', function () {
+            var layer = L.polygon([p2ll(100, 150), p2ll(150, 200), p2ll(200, 100), p2ll(100, 100)]).addTo(this.map),
+                called = 0,
+                call = function () {called++;};
+            this.map.on('editable:vertex:mouseover', call);
+            layer.enableEdit();
+            assert.equal(called, 0);
+            happen.at("mouseover", 100, 150);
+            assert.ok(called);
+            this.map.off('editable:vertex:mouseover', call);
+            layer.remove();
+        });
+
+        it('should fire editable:drawing:mouseout after hovering out of a vertex', function () {
+            var layer = L.polygon([p2ll(100, 150), p2ll(150, 200), p2ll(200, 100), p2ll(100, 100)]).addTo(this.map),
+                called = 0,
+                call = function () {called++;};
+            this.map.on('editable:vertex:mouseout', call);
+            layer.enableEdit();
+            assert.equal(called, 0);
+            happen.at("mouseout", 100, 150);
+            assert.ok(called);
+            this.map.off('editable:vertex:mouseout', call);
+            layer.remove();
+        });
     });
 
     describe('Multi', function () {

--- a/test/PolylineEditor.js
+++ b/test/PolylineEditor.js
@@ -592,6 +592,32 @@ describe('L.PolylineEditor', function() {
             layer.remove();
         });
 
+        it('should fire editable:drawing:mouseover after hovering over vertex', function () {
+            var layer = L.polyline([p2ll(100, 100), p2ll(150, 150)]).addTo(this.map),
+                called = 0,
+                call = function () {called++;};
+            this.map.on('editable:vertex:mouseover', call);
+            layer.enableEdit();
+            assert.equal(called, 0);
+            happen.at("mouseover", 100, 100);
+            assert.ok(called);
+            this.map.off('editable:vertex:mouseover', call);
+            layer.remove();
+        });
+
+        it('should fire editable:drawing:mouseout after hovering out of a vertex', function () {
+            var layer = L.polyline([p2ll(100, 100), p2ll(150, 150)]).addTo(this.map),
+                called = 0,
+                call = function () {called++;};
+            this.map.on('editable:vertex:mouseout', call);
+            layer.enableEdit();
+            assert.equal(called, 0);
+            happen.at("mouseout", 100, 100);
+            assert.ok(called);
+            this.map.off('editable:vertex:mouseout', call);
+            layer.remove();
+        });
+
         it('should send editable:drawing:click before adding vertex', function () {
             var called = 0,
                 line,


### PR DESCRIPTION
Hey,

This is just a simple change that exposes the `mouseover` and `mouseout` events of `VertexMarker`.
I need this to display a tooltip when the user's mouse enters the vertex marker and I'm sure it will be useful to others with different needs.

Thanks :smiley: