### PR TITLE
only use large "touch" vertex icons on mobile devices

### DIFF
--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -150,7 +150,7 @@
         },
 
         createVertexIcon: function (options) {
-            return L.Browser.touch ? new L.Editable.TouchVertexIcon(options) : new L.Editable.VertexIcon(options);
+            return L.Browser.mobile && L.Browser.touch ? new L.Editable.TouchVertexIcon(options) : new L.Editable.VertexIcon(options);
         },
 
         createEditLayer: function () {


### PR DESCRIPTION
Some (most?) desktop browsers are identified by leaflet as "touch"-capable (see https://github.com/Leaflet/Leaflet/issues/5266), but normally you wouldn't want to use extra large drag vertices on these?! This workaround idea is stolen from https://github.com/Leaflet/Leaflet.draw/issues/692#issuecomment-293500346