### PR TITLE
Fix error if using shapeAt within line boundaries but outside of tolerance

### DIFF
--- a/example/delete-shape.html
+++ b/example/delete-shape.html
@@ -18,8 +18,12 @@
   <div id='map'></div>
 
 <script type="text/javascript">
-var startPoint = [43.1249, 1.254];
-var map = L.map('map', {editable: true}).setView(startPoint, 16),
+    var startPoint = [43.1249, 1.254];
+    var svgRenderer = L.svg({tolerance: 10}); // Set tolerance to allow fuzzy hit detection for a line.
+    var map = L.map('map', {
+        editable: true,
+        renderer: svgRenderer
+    }).setView(startPoint, 16),
     tilelayer = L.tileLayer('http://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="http://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
 
     L.NewLineControl = L.Control.extend({
@@ -71,9 +75,24 @@ var map = L.map('map', {editable: true}).setView(startPoint, 16),
     var deleteShape = function (e) {
       if ((e.originalEvent.ctrlKey || e.originalEvent.metaKey) && this.editEnabled()) this.editor.deleteShapeAt(e.latlng);
     };
+    // Attach listeners for direct click on a shape.
     map.on('layeradd', function (e) {
         if (e.layer instanceof L.Path) e.layer.on('click', L.DomEvent.stop).on('click', deleteShape, e.layer);
         if (e.layer instanceof L.Path) e.layer.on('dblclick', L.DomEvent.stop).on('dblclick', e.layer.toggleEdit);
+    });
+    // If we click elsewhere on the map, look for a nearby shape (given renderer tolerance).
+    map.on('click', function (e) {
+        if (e.originalEvent.ctrlKey || e.originalEvent.metaKey) {
+            map.eachLayer(function (layer) {
+                // Look for layer that's an editable feature.
+                if (typeof layer.shapeAt === 'function') {
+                    var foundShape = layer.shapeAt(e.latlng);
+                    if (foundShape !== null && layer.editEnabled()) {
+                        layer.editor.deleteShape(layer.getLatLngs());
+                    }
+                }
+            });
+        }
     });
 
     var line = L.polyline([
@@ -82,6 +101,12 @@ var map = L.map('map', {editable: true}).setView(startPoint, 16),
         [43.1291, 1.261],
     ]).addTo(map);
     line.enableEdit();
+
+    var line2 = L.polyline([
+        [43.1291, 1.252],
+        [43.1308, 1.255]
+    ]).addTo(map);
+    line2.enableEdit();
 
     var multi = L.polygon([
       [

--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -1816,6 +1816,7 @@
             if (!latlngs) return false;
             var i, k, len, part = [], p,
                 w = this._clickTolerance();
+            if (latlngs instanceof L.LatLng) latlngs = [latlngs]
             this._projectLatlngs(latlngs, part, this._pxBounds);
             part = part[0];
             p = this._map.latLngToLayerPoint(l);


### PR DESCRIPTION
The delete-shape example has been updated to show the error.

To recreate, remove the fix in Leaflet.Editable.js and then ctrl+click within the rectangular bounds of a line but outside of the click tolerance area.

Error would then be:

```
Leaflet.Editable.js:1825 Uncaught TypeError: Cannot read property 'length' of undefined
    at e.isInLatLngs (Leaflet.Editable.js:1825)
    at e.shapeAt (Leaflet.Editable.js:1811)
    at delete-shape.html:89

```

leaflet _projectLatlngs method expects that the latlngs supplied are only ever an array, not a LatLng object.