### PR TITLE
Fix resizing circle when using L.CRS.Simple

### DIFF
--- a/src/Leaflet.Editable.js
+++ b/src/Leaflet.Editable.js
@@ -1709,7 +1709,12 @@
         },
 
         resize: function (e) {
-            var radius = this.feature._latlng.distanceTo(e.latlng);
+            var radius;
+            if (this.feature._map && this.feature._map.options && this.feature._map.options.crs) {
+                radius = this.feature._map.options.crs.distance(this.feature._latlng, e.latlng)
+            } else {
+                radius = this.feature._latlng.distanceTo(e.latlng);
+            }
             this.feature.setRadius(radius);
         },
 


### PR DESCRIPTION
When resizing circle on a map with the option: crs: L.CRS.Simple the circle radius is invalid
* Repro link: https://codepen.io/socolin/pen/qBBrzMO
* Fixed version: https://codepen.io/socolin/pen/xxxqoyb

The problem seems to be from this line: 
https://github.com/Leaflet/Leaflet.Editable/blob/master/src/Leaflet.Editable.js#L1712
When it compute the new radius size, it ignore the map `crs` option and use `Earth.distance(this, toLatLng(other));`

https://github.com/Leaflet/Leaflet/blob/37d2fd15ad6518c254fae3e033177e96c48b5012/src/geo/LatLng.js#L75
