### PR TITLE
Add circle marker editor

### DIFF
--- a/doc/api.html
+++ b/doc/api.html
@@ -60,7 +60,7 @@ See <a href="#editable"><code>Editable</code></a> events for the list of events 
 		<td><code><b>editOptions</b></code></td>
 		<td><code>hash</code>
 		<td><code>{}</code></td>
-		<td>Options to pass to L.Editable when instanciating.</td>
+		<td>Options to pass to L.Editable when instantiating.</td>
 	</tr>
 </tbody></table>
 </section>
@@ -149,6 +149,12 @@ the behaviour: using options, listening to events, or extending.</p>
 		<td><code>L.Marker</code></td>
 		<td>Class to be used when creating a new Marker.</td>
 	</tr>
+	<tr id='editable-circlemarkerclass'>
+		<td><code><b>circleMarkerClass</b></code></td>
+		<td><code>class</code>
+		<td><code>L.CircleMarker</code></td>
+		<td>Class to be used when creating a new CircleMarker.</td>
+	</tr>
 	<tr id='editable-rectangleclass'>
 		<td><code><b>rectangleClass</b></code></td>
 		<td><code>class</code>
@@ -202,6 +208,12 @@ the behaviour: using options, listening to events, or extending.</p>
 		<td><code>class</code>
 		<td><code>MarkerEditor</code></td>
 		<td>Class to be used as Marker editor.</td>
+	</tr>
+	<tr id='editable-circlemarkereditorclass'>
+		<td><code><b>circleMarkerEditorClass</b></code></td>
+		<td><code>class</code>
+		<td><code>CircleMarkerEditor</code></td>
+		<td>Class to be used as CircleMarker editor.</td>
 	</tr>
 	<tr id='editable-rectangleeditorclass'>
 		<td><code><b>rectangleEditorClass</b></code></td>
@@ -411,6 +423,16 @@ the behaviour: using options, listening to events, or extending.</p>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
 		<td>Fired when user <code>mousedown</code> a vertex.</td>
 	</tr>
+	<tr id='editable-editable:vertex:mouseover'>
+		<td><code><b>editable:vertex:mouseover</b>
+		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
+		<td>Fired when user mouse enters the vertex</td>
+	</tr>
+	<tr id='editable-editable:vertex:mouseout'>
+		<td><code><b>editable:vertex:mouseout</b>
+		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
+		<td>Fired when user mouse leaves the vertex</td>
+	</tr>
 	<tr id='editable-editable:vertex:drag'>
 		<td><code><b>editable:vertex:drag</b>
 		<td><code><a href='#vertexevent'>VertexEvent</a></code></td>
@@ -518,6 +540,13 @@ If <code>options</code> is given, it will be passed to the Polygon class constru
 		<td>Start adding a Marker. If <code>latlng</code> is given, the Marker will be shown first at this point.
 In any case, it will follow the user mouse, and will have a final <code>latlng</code> on next click (or touch).
 If <code>options</code> is given, it will be passed to the Marker class constructor.</td>
+	</tr>
+	<tr id='editable-startcirclemarker'>
+		<td><code><b>startCircleMarker</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>, <nobr>&lt;hash&gt; <i>options</i></nobr>)</nobr></code></td>
+		<td><code>L.CircleMarker</code></td>
+		<td>Start adding a CircleMarker. If <code>latlng</code> is given, the CircleMarker will be shown first at this point.
+In any case, it will follow the user mouse, and will have a final <code>latlng</code> on next click (or touch).
+If <code>options</code> is given, it will be passed to the CircleMarker class constructor.</td>
 	</tr>
 	<tr id='editable-startrectangle'>
 		<td><code><b>startRectangle</b>(<nobr>&lt;L.LatLng&gt; <i>latlng</i></nobr>, <nobr>&lt;hash&gt; <i>options</i></nobr>)</nobr></code></td>
@@ -1375,6 +1404,45 @@ instance when listening for events like <code>editable:vertex:ctrlclick</code>.
 	</tr>
 </tbody></table>
 </section>
+
+<h2 id='circlemarkereditor'>CircleMarkerEditor</h2>
+<p>Editor for CircleMarker.</p>
+
+<h3 id='' class="section">Methods</h3>
+
+
+
+<div class='accordion'>
+<!-- 	<label>Show inherited <a href='#baseeditor-method'>Methods from BaseEditor</a>.</label> -->
+	<label><span class='expander'>▶</span> Methods inherited from <a href='#baseeditor'>BaseEditor</a></label>
+	<div class='accordion-content'><section data-type='[object Object]'>
+
+
+<table><thead>
+	<tr>
+		<th>Method</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='circlemarkereditor-enable'>
+		<td><code><b>enable</b>()</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Set up the drawing tools for the feature to be editable.</td>
+	</tr>
+	<tr id='circlemarkereditor-disable'>
+		<td><code><b>disable</b>()</nobr></code></td>
+		<td><code>this</code></td>
+		<td>Remove the drawing tools for the feature.</td>
+	</tr>
+	<tr id='circlemarkereditor-drawing'>
+		<td><code><b>drawing</b>()</nobr></code></td>
+		<td><code>boolean</code></td>
+		<td>Return true if any drawing action is ongoing with this editor.</td>
+	</tr>
+</tbody></table>
+</section></div>
+</div>
 
 
 	</div>

--- a/test/CircleMarkerEditor.js
+++ b/test/CircleMarkerEditor.js
@@ -1,0 +1,234 @@
+'use strict';
+describe('L.CircleMarkerEditor', function() {
+    var p2ll;
+
+    before(function () {
+        this.map = map;
+        map.setZoom(16);  // So we don't need to use enormous radius.
+        p2ll = function (x, y) {
+            return map.layerPointToLatLng([x, y]);
+        };
+    });
+
+    describe('#startCircleMarker()', function() {
+
+        it('should create circleMarker and editor', function() {
+            var layer = this.map.editTools.startCircleMarker();
+            assert.ok(layer);
+            assert.ok(layer.editor);
+            assert.notOk(map.hasLayer(layer));
+            layer.editor.disable();
+        });
+
+        it('should add layer to map at first click', function() {
+            var layer = this.map.editTools.startCircleMarker();
+            assert.notOk(map.hasLayer(layer));
+            happen.drawingClick(300, 300);
+            assert.ok(map.hasLayer(layer));
+            layer.remove();
+        });
+
+    });
+
+    describe('#enableEdit()', function() {
+
+        it('should attach editor', function () {
+            var layer = L.circleMarker(p2ll(200, 200)).addTo(this.map);
+            layer.enableEdit();
+            assert.ok(layer.editor);
+            layer.remove();
+        });
+
+    });
+
+    describe('#disableEdit()', function() {
+
+        it('should stop editing on disableEdit', function () {
+            var layer = L.circleMarker(p2ll(200, 200)).addTo(this.map);
+            layer.enableEdit();
+            assert.ok(layer.editor);
+            layer.disableEdit();
+            assert.notOk(layer.editor);
+            layer.remove();
+        });
+
+    });
+
+
+    describe('#enableDragging()', function () {
+
+        it('should drag a circleMarker', function (done) {
+            var layer = L.circleMarker(p2ll(200, 200), {radius: 20}).addTo(this.map),
+                before = layer._latlng.lat;
+            layer.enableEdit();
+            assert.equal(before, layer._latlng.lat);
+            happen.drag(210, 210, 220, 220, function () {
+                assert.notEqual(before, layer._latlng.lat);
+                layer.remove();
+                done();
+            });
+        });
+
+        it('should send editable:dragstart event', function (done) {
+            var layer = L.circleMarker(p2ll(200, 200), {radius: 20}).addTo(this.map),
+                called = 0,
+                call = function () {called++;};
+            layer.on('editable:dragstart', call);
+            layer.enableEdit();
+            assert.equal(called, 0);
+            happen.drag(210, 210, 220, 220, function () {
+                assert.equal(called, 1);
+                layer.remove();
+                done();
+            });
+        });
+
+        it('should send editable:dragend event', function (done) {
+            var layer = L.circleMarker(p2ll(200, 200), {radius: 20}).addTo(this.map),
+                called = 0,
+                call = function () {called++;};
+            layer.on('editable:dragend', call);
+            layer.enableEdit();
+            assert.equal(called, 0);
+            happen.drag(210, 210, 220, 220, function () {
+                assert.equal(called, 1);
+                layer.remove();
+                done();
+            });
+        });
+
+        it('should send editable:drag event', function (done) {
+            var layer = L.circleMarker(p2ll(200, 200), {radius: 20}).addTo(this.map),
+                called = 0,
+                call = function () {called++;};
+            layer.on('editable:drag', call);
+            layer.enableEdit();
+            assert.notOk(called);
+            happen.drag(210, 210, 220, 220, function () {
+                assert.ok(called);
+                layer.remove();
+                done();
+            });
+        });
+
+    });
+
+
+    describe('#events', function () {
+
+        it('should fire editable:drawing:start on startMarker call', function () {
+            var called = 0,
+                call = function () {called++;};
+            this.map.on('editable:drawing:start', call);
+            var other = this.map.editTools.startMarker();
+            assert.equal(called, 1);
+            this.map.off('editable:drawing:start', call);
+            other.editor.disable();
+            assert.notOk(this.map.editTools._drawingEditor);
+        });
+
+        it('should fire editable:drawing:end on click', function () {
+            var called = 0,
+                call = function () {called++;};
+            this.map.on('editable:drawing:end', call);
+            var other = this.map.editTools.startMarker();
+            assert.equal(called, 0);
+            happen.drawingClick(450, 450);
+            assert.equal(called, 1);
+            this.map.off('editable:drawing:end', call);
+            other.remove();
+            assert.equal(called, 1);
+        });
+
+        it('should fire editable:drawing:commit on finish', function () {
+            var called = 0,
+                call = function () {called++;};
+            this.map.on('editable:drawing:commit', call);
+            var other = this.map.editTools.startMarker();
+            assert.equal(called, 0);
+            happen.drawingClick(450, 450);
+            assert.equal(called, 1);
+            this.map.off('editable:drawing:commit', call);
+            other.remove();
+            assert.equal(called, 1);
+        });
+
+        it('should fire editable:drawing:end on stopDrawing', function () {
+            var called = 0,
+                call = function () {called++;};
+            this.map.on('editable:drawing:end', call);
+            var other = this.map.editTools.startMarker();
+            this.map.editTools.stopDrawing();
+            assert.equal(called, 1);
+            this.map.off('editable:drawing:end', call);
+            other.remove();
+            assert.equal(called, 1);
+        });
+
+        it('should fire editable:drawing:clicked before end/commit on click', function () {
+            var first = null, last,
+                setFirst = function (e) {if(first === null) first = e.type;},
+                setLast = function (e) {last = e.type;};
+            this.map.on('editable:drawing:end', setFirst);
+            this.map.on('editable:drawing:clicked', setFirst);
+            this.map.on('editable:drawing:commit', setFirst);
+            this.map.on('editable:drawing:end', setLast);
+            this.map.on('editable:drawing:clicked', setLast);
+            this.map.on('editable:drawing:commit', setLast);
+            var other = this.map.editTools.startMarker();
+            happen.drawingClick(450, 450);
+            assert.equal(first, 'editable:drawing:clicked');
+            assert.equal(last, 'editable:drawing:end');
+            this.map.off('editable:drawing:end', setFirst);
+            this.map.off('editable:drawing:clicked', setFirst);
+            this.map.off('editable:drawing:commit', setFirst);
+            this.map.off('editable:drawing:end', setLast);
+            this.map.off('editable:drawing:clicked', setLast);
+            this.map.off('editable:drawing:commit', setLast);
+            other.remove();
+        });
+
+        it('should not fire editable:drawing:commit on stopDrawing', function () {
+            var called = 0,
+                call = function () {called++;};
+            this.map.on('editable:drawing:commit', call);
+            var other = this.map.editTools.startMarker();
+            this.map.editTools.stopDrawing();
+            assert.equal(called, 0);
+            this.map.off('editable:drawing:commit', call);
+            other.remove();
+            assert.equal(called, 0);
+        });
+
+        it('should fire editable:drawing:move on mousemove while drawing', function () {
+            var called = 0,
+                call = function () {called++;};
+            this.map.on('editable:drawing:move', call);
+            var other = this.map.editTools.startMarker();
+            assert.equal(called, 0);
+            happen.at('mousemove', 450, 450);
+            assert.equal(called, 1);
+            happen.drawingClick(450, 450);
+            this.map.off('editable:drawing:move', call);
+            other.remove();
+            assert.equal(called, 1);
+        });
+
+        it('should fire editable:drawing:move on mousemove while moving marker', function (done) {
+            var called = 0,
+                call = function () {called++;};
+            var layer = L.marker(p2ll(200, 200)).addTo(this.map);
+            layer.enableEdit();
+            assert.equal(called, 0);
+            this.map.on('editable:drawing:move', call);
+            happen.drag(200, 190, 210, 210, function () {
+                assert.ok(called > 0);
+                map.off('editable:drawing:move', call);
+                layer.remove();
+                done();
+            });
+        });
+
+    });
+
+});

--- a/test/index.html
+++ b/test/index.html
@@ -28,6 +28,7 @@
         <script src="./MarkerEditor.js"></script>
         <script src="./RectangleEditor.js"></script>
         <script src="./CircleEditor.js"></script>
+        <script src="./CircleMarkerEditor.js"></script>
         <style type="text/css">
             #mocha {
                 position: absolute;


### PR DESCRIPTION
Replacement of #180 using specific branch instead of master

Add CircleMarkerEditor for editable CircleMarkers based off the current MarkerEditor.

I haven't update the example files - not sure if you want want them updated?

Resolves https://github.com/Leaflet/Leaflet.Editable/issues/120