### PR TITLE
feat: only show visible vertextmarkers

### DIFF
--- a/test/MiddleMarker.js
+++ b/test/MiddleMarker.js
@@ -1,7 +1,4 @@
 describe('L.MiddleMarker', () => {
-  let mouse
-  let polyline
-
   before(function () {
     this.map = map
   })

--- a/test/VertexMarker.js
+++ b/test/VertexMarker.js
@@ -13,6 +13,21 @@ describe('L.Editable.VertexMarker', () => {
     })
   })
 
+  describe('#init', () => {
+    it('should only show visible vertex', function () {
+      const latlngs = [p2ll(-10, -15), p2ll(100, 150), p2ll(150, 200), p2ll(200, 100)]
+      const layer = L.polyline(latlngs).addTo(this.map)
+      layer.enableEdit()
+      assert.notOk(latlngs[0].__vertex)
+      assert.equal(qsa('.leaflet-vertex-icon').length, 3)
+      map.zoomOut(1, {animate: false})
+      assert.ok(latlngs[0].__vertex)
+      assert.equal(qsa('.leaflet-vertex-icon').length, 4)
+      map.zoomIn()
+      layer.remove()
+    })
+  })
+
   describe('#split', () => {
     it('should split line at its index', function () {
       const latlngs = [p2ll(100, 150), p2ll(150, 200), p2ll(200, 100)]

--- a/test/_pre.js
+++ b/test/_pre.js
@@ -44,9 +44,9 @@ happen.drag = (fromX, fromY, toX, toY, then, delay) => {
     }
   }, delay || 600)
 }
-happen.drawingClick = function (x, y) {
-  this.at('mousedown', x, y)
-  this.at('mouseup', x, y)
+happen.drawingClick = (x, y) => {
+  happen.at('mousedown', x, y)
+  happen.at('mouseup', x, y)
 }
 chai.Assertion.addMethod('nearLatLng', function (expected, delta) {
   delta = delta || 1e-4


### PR DESCRIPTION
This may improve a lot performance when editing a small piece of a huge path.