### PR TITLE
Update tile example server URL

### DIFF
--- a/example/change-line-colour-on-editing.html
+++ b/example/change-line-colour-on-editing.html
@@ -20,7 +20,7 @@
 <script type="text/javascript">
 var startPoint = [43.1249, 1.254];
 var map = L.map('map', {editable: true}).setView(startPoint, 16),
-    tilelayer = L.tileLayer('https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
+    tilelayer = L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
 
     var line = L.polyline([
         [43.1292, 1.256],

--- a/example/continue-line.html
+++ b/example/continue-line.html
@@ -20,7 +20,7 @@
 <script type="text/javascript">
 var startPoint = [43.1249, 1.254];
 var map = L.map('map', {editable: true}).setView(startPoint, 16),
-    tilelayer = L.tileLayer('https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
+    tilelayer = L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
 
     var line = L.polyline([
         [43.1292, 1.256],

--- a/example/create-hole-on-click.html
+++ b/example/create-hole-on-click.html
@@ -20,7 +20,7 @@
 <script type="text/javascript">
 var startPoint = [43.1249, 1.254];
 var map = L.map('map', {editable: true}).setView(startPoint, 16),
-    tilelayer = L.tileLayer('https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
+    tilelayer = L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
 
     var poly = L.polygon([
       [

--- a/example/delete-shape.html
+++ b/example/delete-shape.html
@@ -20,7 +20,7 @@
 <script type="text/javascript">
 var startPoint = [43.1249, 1.254];
 var map = L.map('map', {editable: true}).setView(startPoint, 16),
-    tilelayer = L.tileLayer('https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
+    tilelayer = L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
 
     L.NewLineControl = L.Control.extend({
 

--- a/example/index.html
+++ b/example/index.html
@@ -20,7 +20,7 @@
 <script type="text/javascript">
 var startPoint = [43.1249, 1.254];
 var map = L.map('map', {editable: true}).setView(startPoint, 16),
-    tilelayer = L.tileLayer('https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
+    tilelayer = L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
 
     L.EditControl = L.Control.extend({
 

--- a/example/multipolygon.html
+++ b/example/multipolygon.html
@@ -20,7 +20,7 @@
 <script type="text/javascript">
 var startPoint = [43.1249, 1.254];
 var map = L.map('map', {editable: true}).setView(startPoint, 16),
-    tilelayer = L.tileLayer('https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
+    tilelayer = L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
 
     L.NewPolygonControl = L.Control.extend({
 

--- a/example/snapping.html
+++ b/example/snapping.html
@@ -26,7 +26,7 @@
 <script type="text/javascript">
 var startPoint = [43.1249, 1.254];
 var map = L.map('map', {editable: true}).setView(startPoint, 16),
-    tilelayer = L.tileLayer('https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
+    tilelayer = L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
 
     L.NewLineControl = L.Control.extend({
 

--- a/example/tooltip-when-drawing.html
+++ b/example/tooltip-when-drawing.html
@@ -35,7 +35,7 @@
 <script type="text/javascript">
 var startPoint = [43.1249, 1.254];
 var map = L.map('map', {editable: true}).setView(startPoint, 16),
-    tilelayer = L.tileLayer('https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
+    tilelayer = L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> Tiles \u00a9 HOT'}).addTo(map);
 
     L.NewLineControl = L.Control.extend({
 

--- a/example/undo-redo.html
+++ b/example/undo-redo.html
@@ -20,7 +20,7 @@
 <script type="text/javascript">
 var startPoint = [43.1249, 1.254];
 var map = L.map('map', {editable: true}).setView(startPoint, 16),
-    tilelayer = L.tileLayer('https://tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> | Use Ctrl-Z to undo / Ctrl-Shift-Z to redo'}).addTo(map);
+    tilelayer = L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {maxZoom: 20, attribution: 'Data \u00a9 <a href="https://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a> | Use Ctrl-Z to undo / Ctrl-Shift-Z to redo'}).addTo(map);
     L.NewLineControl = L.Control.extend({
 
         options: {

--- a/test/index.html
+++ b/test/index.html
@@ -55,7 +55,7 @@
         <script>
             var startPoint = [43.1249, 1.254],
                 map = L.map('map', {editable: true}).setView(startPoint, 16),
-                tilelayer = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 19, attribution: 'Data \u00a9 <a href="http://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a>'}).addTo(map);
+                tilelayer = L.tileLayer('https://a.tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 19, attribution: 'Data \u00a9 <a href="http://www.openstreetmap.org/copyright"> OpenStreetMap Contributors </a>'}).addTo(map);
             var runner = window.mocha.run(function (failures) {
                 if (window.location.hash !== '#debug') qs('#mocha').style.display = 'block';
                 console.log(failures);


### PR DESCRIPTION
The examples currently are broken.

I updated the examples to use `a.tile.openstreetmap.fr` instead of `tile.openstreetmap.fr`.

I think it's fine regarding the [Usage Policy](https://www.openstreetmap.fr/usage/)