### PR TITLE
Fix link to leaflet.geometryutil

### DIFF
--- a/example/snapping.html
+++ b/example/snapping.html
@@ -8,7 +8,7 @@
   <script src="https://npmcdn.com/leaflet@1.2.0/dist/leaflet.js"></script>
   <script src="https://npmcdn.com/leaflet.path.drag/src/Path.Drag.js"></script>
   <script src="../src/Leaflet.Editable.js"></script>
-  <script src="https://makinacorpus.github.io/Leaflet.Snap/leaflet.geometryutil.js"></script>
+  <script src="https://makinacorpus.github.io/Leaflet.Snap/docs/leaflet.geometryutil.js"></script>
   <script src="https://makinacorpus.github.io/Leaflet.Snap/leaflet.snap.js"></script>
 
   <style type='text/css'>


### PR DESCRIPTION
Update the `leaflet.geometryutil.js` URL.

An error is thrown, but at least the example works.